### PR TITLE
Add bento-style personal landing page template

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shawn Mendes – Creative Backend Developer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="noise"></div>
+    <div class="app">
+      <aside class="panel panel--stack">
+        <header class="panel__header">
+          <span class="panel__header-icon">{}</span>
+          <span class="panel__header-title">Tech Stack</span>
+        </header>
+        <section class="panel__body">
+          <div class="tag-list">
+            <h3 class="tag-list__title">Core</h3>
+            <ul class="tag-list__grid">
+              <li>Node.js</li>
+              <li>TypeScript</li>
+              <li>React</li>
+              <li>Next.js</li>
+              <li>GraphQL</li>
+              <li>PostgreSQL</li>
+              <li>Prisma</li>
+              <li>Tailwind</li>
+              <li>tRPC</li>
+            </ul>
+          </div>
+          <div class="tag-list">
+            <h3 class="tag-list__title">Tools</h3>
+            <ul class="tag-list__grid">
+              <li>VS Code</li>
+              <li>Docker</li>
+              <li>Figma</li>
+              <li>Raycast</li>
+              <li>Notion</li>
+              <li>Linear</li>
+            </ul>
+          </div>
+        </section>
+        <footer class="panel__footer">
+          <p>Currently crafting delightful developer experiences at midnight.</p>
+        </footer>
+      </aside>
+      <main class="grid">
+        <section class="card card--profile">
+          <div class="profile">
+            <img src="https://avatars.githubusercontent.com/u/000000?v=4" alt="Shawn Mendes avatar" />
+            <div>
+              <h1>Shawn Mendes</h1>
+              <p>@ezzzshaw</p>
+            </div>
+            <span class="status status--active">Available for work</span>
+          </div>
+          <p class="intro">
+            I build expressive backend platforms with a focus on developer empathy and scale. Based in Goa, India.
+          </p>
+          <div class="cta-group">
+            <a class="btn" href="mailto:hello@shawndev.com">hello@shawndev.com</a>
+            <a class="btn btn--ghost" href="https://shawndev.com" target="_blank" rel="noreferrer">Portfolio</a>
+          </div>
+        </section>
+
+        <section class="card card--tools">
+          <header class="card__header">
+            <span class="icon">☀️</span>
+            <h2>Daily Tool Stack</h2>
+          </header>
+          <div class="tool-list">
+            <article class="tool">
+              <span class="tool__label">Terminal</span>
+              <p class="tool__desc">Warp + tmux sessions with dotfile magic.</p>
+            </article>
+            <article class="tool">
+              <span class="tool__label">Code</span>
+              <p class="tool__desc">VS Code, GitHub Copilot, ESLint, Prettier.</p>
+            </article>
+            <article class="tool">
+              <span class="tool__label">Databases</span>
+              <p class="tool__desc">PlanetScale, Supabase, Redis Cloud.</p>
+            </article>
+            <article class="tool">
+              <span class="tool__label">Ops</span>
+              <p class="tool__desc">Vercel, Fly.io, GitHub Actions pipelines.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="card card--quote">
+          <p class="quote">
+            "Code is poetry, but production is the stage. I obsess over both to ship resilient systems with a human touch."
+          </p>
+          <span class="quote__source">— Shawn Mendes</span>
+        </section>
+
+        <section class="card card--project">
+          <header class="card__header">
+            <span class="icon">📦</span>
+            <h2>Current Focus</h2>
+          </header>
+          <p class="card__body">
+            Building a modular SaaS starter kit with multi-tenant billing, generative AI tooling, and a delightful onboarding flow.
+          </p>
+          <ul class="pill-group">
+            <li>Monorepos</li>
+            <li>Event-driven</li>
+            <li>Design Systems</li>
+          </ul>
+        </section>
+
+        <section class="card card--links">
+          <h2>Links</h2>
+          <ul class="social-links">
+            <li><a href="https://twitter.com/ezzzshaw">Twitter</a></li>
+            <li><a href="https://github.com/ezzzshaw">GitHub</a></li>
+            <li><a href="https://dribbble.com/ezzzshaw">Dribbble</a></li>
+            <li><a href="https://www.linkedin.com/in/ezzzshaw">LinkedIn</a></li>
+          </ul>
+        </section>
+
+        <section class="card card--journal">
+          <header class="card__header">
+            <span class="icon">🛰️</span>
+            <h2>Signal Log</h2>
+          </header>
+          <ul class="journal">
+            <li>
+              <span class="journal__time">08:00</span>
+              <p>Standup sync with the platform crew and planning the next release train.</p>
+            </li>
+            <li>
+              <span class="journal__time">12:30</span>
+              <p>Pairing session on a gnarly database migration — chaos avoided.</p>
+            </li>
+            <li>
+              <span class="journal__time">20:15</span>
+              <p>Late night writing session for the "Scaling with Empathy" newsletter.</p>
+            </li>
+          </ul>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,495 @@
+:root {
+  color-scheme: dark;
+  --bg: #06060d;
+  --panel-bg: rgba(10, 10, 18, 0.85);
+  --card-bg: rgba(14, 14, 25, 0.9);
+  --card-border: rgba(255, 255, 255, 0.07);
+  --accent: #8b5cf6;
+  --accent-soft: rgba(139, 92, 246, 0.2);
+  --text: #f8f8ff;
+  --text-dim: rgba(248, 248, 255, 0.6);
+  --muted: rgba(248, 248, 255, 0.35);
+  --font-body: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --radius-lg: 28px;
+  --radius-sm: 16px;
+  --shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+  --shadow-soft: 0 20px 35px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-body);
+  background: radial-gradient(circle at top, rgba(139, 92, 246, 0.35), transparent 55%), var(--bg);
+  color: var(--text);
+  position: relative;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+.noise {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.16;
+  mix-blend-mode: screen;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.25'/%3E%3C/svg%3E");
+  z-index: 0;
+}
+
+.app {
+  position: relative;
+  width: min(1200px, 100%);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  grid-template-columns: minmax(240px, 280px) 1fr;
+  z-index: 1;
+}
+
+.panel {
+  backdrop-filter: blur(18px);
+  background: var(--panel-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--card-border);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.panel__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.panel__header-icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 1.15rem;
+}
+
+.panel__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel__footer {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--text-dim);
+}
+
+.tag-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tag-list__title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.tag-list__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.tag-list__grid li {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+  color: var(--text-dim);
+}
+
+.grid {
+  display: grid;
+  gap: clamp(1.5rem, 2.75vw, 2rem);
+  grid-template-columns: repeat(12, 1fr);
+  grid-auto-rows: minmax(130px, auto);
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.card--profile {
+  grid-column: span 7;
+}
+
+.card--tools {
+  grid-column: span 5;
+}
+
+.card--quote {
+  grid-column: span 5;
+}
+
+.card--project {
+  grid-column: span 7;
+}
+
+.card--links {
+  grid-column: span 4;
+}
+
+.card--journal {
+  grid-column: span 8;
+}
+
+.profile {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 1rem;
+}
+
+.profile img {
+  width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  object-fit: cover;
+  border: 2px solid var(--accent);
+  box-shadow: 0 12px 24px rgba(139, 92, 246, 0.35);
+}
+
+.profile h1 {
+  font-size: 1.6rem;
+  margin: 0;
+}
+
+.profile p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+}
+
+.status {
+  justify-self: end;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(16, 185, 129, 0.16);
+  color: #34d399;
+  border: 1px solid rgba(52, 211, 153, 0.2);
+}
+
+.intro {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--text-dim);
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 12px;
+  padding: 0.65rem 1.25rem;
+  font-weight: 600;
+  text-decoration: none;
+  background: var(--accent);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(139, 92, 246, 0.4);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-family: var(--font-mono);
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: rgba(139, 92, 246, 0.12);
+  color: var(--accent);
+  font-size: 1.2rem;
+}
+
+.tool-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.tool {
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 16px;
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.tool__label {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.tool__desc {
+  margin: 0.35rem 0 0;
+  color: var(--text-dim);
+  line-height: 1.6;
+}
+
+.quote {
+  font-size: 1.2rem;
+  line-height: 1.8;
+  font-family: "New York", "Iowan Old Style", Georgia, serif;
+  color: rgba(255, 255, 255, 0.88);
+  margin: 0;
+}
+
+.quote__source {
+  font-size: 0.85rem;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+}
+
+.card__body {
+  margin: 0;
+  color: var(--text-dim);
+  line-height: 1.6;
+}
+
+.pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  list-style: none;
+  margin: 0;
+}
+
+.pill-group li {
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(139, 92, 246, 0.18);
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.social-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.social-links a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.social-links a::before {
+  content: "↗";
+  font-size: 0.9rem;
+  transform: translateY(-1px);
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.social-links a:hover::before {
+  opacity: 1;
+  transform: translate(4px, -1px);
+}
+
+.journal {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.journal li {
+  display: grid;
+  grid-template-columns: 75px 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.journal__time {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.journal p {
+  margin: 0;
+  color: var(--text-dim);
+  line-height: 1.65;
+}
+
+@media (max-width: 1100px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    position: sticky;
+    top: 1.5rem;
+    height: max-content;
+  }
+
+  .grid {
+    grid-template-columns: repeat(6, 1fr);
+  }
+
+  .card--profile,
+  .card--project {
+    grid-column: span 6;
+  }
+
+  .card--tools,
+  .card--quote,
+  .card--links {
+    grid-column: span 3;
+  }
+
+  .card--journal {
+    grid-column: span 6;
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .panel {
+    position: static;
+  }
+
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .card {
+    grid-column: span 2;
+  }
+
+  .profile {
+    grid-template-columns: 1fr;
+    justify-items: start;
+  }
+
+  .status {
+    justify-self: start;
+  }
+
+  .cta-group {
+    width: 100%;
+  }
+
+  .btn {
+    flex: 1;
+  }
+
+  .journal li {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .btn {
+    width: 100%;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+
+  .panel {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a personal landing page layout with profile, tool stack, and activity sections
- style the page with a dark, glassmorphism-inspired bento grid aesthetic and responsive tweaks

## Testing
- not run (static HTML/CSS)

------
https://chatgpt.com/codex/tasks/task_e_68cffab81b2c8329bfce1d19d0b8fee3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a personal portfolio landing page featuring a sidebar tech stack, profile card, daily tools, inspirational quote, current focus, external links, and a journal/log.
  * Added contact and portfolio links with a status indicator and intro blurb.
  * Implemented a fully responsive two-column layout that adapts to smaller screens.

* Style
  * Applied a dark, glassy theme with consistent typography, spacing, and interactive hover/active states.
  * Added decorative badges, tag pills, and refined card components for a polished UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->